### PR TITLE
Remove notice on customer_data_groups page

### DIFF
--- a/includes/hooks/admin/siteWide/swPwa.php
+++ b/includes/hooks/admin/siteWide/swPwa.php
@@ -131,11 +131,14 @@ EOSQL
   function listen_constructPaginator( $param ) {
     global $table_definition;
 
-    if ( Request::get_page() == 'orders.php'
-      || Request::get_page() == 'customers.php'
-      || ((Request::get_page() === 'reviews.php') && empty($GLOBALS['action']) || ($GLOBALS['action'] === 'delete' )))
+    if ( in_array(Request::get_page(), ['orders.php', 'customers.php', 'reviews.php'], true)
+      && isset($table_definition['columns']))
     {
-      $index = (int)array_search(TABLE_HEADING_ACTION, array_column($table_definition['columns'], 'name'));
+      $index = array_search(TABLE_HEADING_ACTION, array_column($table_definition['columns'], 'name'));
+      if (!is_int($index)) {
+        $index = -1;
+      }
+
       array_splice($table_definition['columns'], $index, 0, [[
         'name' => HOOK_SWPWA_GUEST,
         'class' => 'text-center',
@@ -146,7 +149,7 @@ EOSQL
 
     }
 
-    if ( Request::get_page() == 'customers.php' ) {
+    if ( Request::get_page() === 'customers.php' ) {
       $guests_query = $GLOBALS['db']->query(<<<'EOSQL'
 SELECT COUNT(*) AS total
   FROM customers c, customers_info ci


### PR DESCRIPTION
While testing the customer_data_groups.php page for an unrelated
reason, noticed that there was a notice in the admin hook.  This
removes that notice and should be easier to manage.

I'm unclear on whether the notice was something that I introduced
with a bad edit or a problem from PWA that I didn't notice before.
The logic said to show if one of three pages with an unset action
or if deleting.  My working hypothesis is that it was supposed to
be either the reviews page should show it if the action was empty
or delete or that all three pages were to show it for empty or
delete actions.

This flips the logic to check if it is one of the three pages and
$table_definition['columns'] is set.  So it won't run on the
customer_data_groups page nor will it attempt to run on any page
without a table_definition.

I also changed the array_search to default to -1 if the result is false 
or a string.  The previous code defaulted to 0 in those cases.  